### PR TITLE
Ignore phpmyadmin config file permission checks

### DIFF
--- a/phpmyadmin/config.inc.php
+++ b/phpmyadmin/config.inc.php
@@ -141,6 +141,12 @@ $cfg['SaveDir'] = '';
 
 $cfg['AllowUserDropDatabase'] = true;
 
+
+/*
+ * Ignore file permissions on the config file.
+ */
+$cfg['CheckConfigurationPermissions'] = false;
+
 /*
  * Include a custom configuration file for phpMyAdmin if it exists locally.
  */


### PR DESCRIPTION
This should fix the "Wrong permissions on configuration file, should not be world writable!" error when accessing phpMyAdmin on Windows machines.