### PR TITLE
Mailhog and PHP 7.1 fix

### DIFF
--- a/php56/provision.sh
+++ b/php56/provision.sh
@@ -150,14 +150,22 @@ configure() {
   cp "${DIR}/php5.6-custom.ini" "/etc/php/5.6/fpm/conf.d/php-custom.ini"
   cp "/srv/config/php-config/opcache.ini" "/etc/php/5.6/fpm/conf.d/opcache.ini"
   cp "/srv/config/php-config/xdebug.ini" "/etc/php/5.6/mods-available/xdebug.ini"
-  cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/5.6/mods-available/mailcatcher.ini"
+  if [[ -e /srv/config/php-config/mailcatcher.ini ]]; then
+    cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/5.6/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/5.6/mods-available/mailcatcher.ini"
+
+  fi
+  if [[ -e /srv/config/php-config/mailhog.ini ]]; then
+    cp "/srv/config/php-config/mailhog.ini" "/etc/php/5.6/mods-available/mailhog.ini"
+    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/5.6/mods-available/mailhog.ini"
+  fi
 
   echo " * Copied ${DIR}/php5.6-fpm.conf                   to /etc/php/5.6/fpm/php-fpm.conf"
   echo " * Copied ${DIR}/php5.6-www.conf                   to /etc/php/5.6/fpm/pool.d/www.conf"
   echo " * Copied ${DIR}/php5.6-custom.ini                 to /etc/php/5.6/fpm/conf.d/php-custom.ini"
   echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/5.6/fpm/conf.d/opcache.ini"
   echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/5.6/mods-available/xdebug.ini"
-  echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/5.6/mods-available/mailcatcher.ini"
+  
 
   service php5.6-fpm restart
 }

--- a/php70/provision.sh
+++ b/php70/provision.sh
@@ -142,7 +142,7 @@ package_install() {
 
 configure() {
   # Copy nginx configuration from local
-  cp "${DIR}/php7.0-upstream.conf" "/etc/nginx/upstreams/php71.conf"
+  cp "${DIR}/php7.0-upstream.conf" "/etc/nginx/upstreams/php70.conf"
 
   # Copy php-fpm configuration from local
   cp "${DIR}/php7.0-fpm.conf" "/etc/php/7.0/fpm/php-fpm.conf"
@@ -150,14 +150,21 @@ configure() {
   cp "${DIR}/php7.0-custom.ini" "/etc/php/7.0/fpm/conf.d/php-custom.ini"
   cp "/srv/config/php-config/opcache.ini" "/etc/php/7.0/fpm/conf.d/opcache.ini"
   cp "/srv/config/php-config/xdebug.ini" "/etc/php/7.0/mods-available/xdebug.ini"
-  cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.0/mods-available/mailcatcher.ini"
+  if [[ -e /srv/config/php-config/mailcatcher.ini ]]; then
+    cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.0/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.0/mods-available/mailcatcher.ini"
+
+  fi
+  if [[ -e /srv/config/php-config/mailhog.ini ]]; then
+    cp "/srv/config/php-config/mailhog.ini" "/etc/php/7.0/mods-available/mailhog.ini"
+    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/7.0/mods-available/mailhog.ini"
+  fi
 
   echo " * Copied ${DIR}/php7.0-fpm.conf                   to /etc/php/7.0/fpm/php-fpm.conf"
   echo " * Copied ${DIR}/php7.0-www.conf                   to /etc/php/7.0/fpm/pool.d/www.conf"
   echo " * Copied ${DIR}/php7.0-custom.ini                 to /etc/php/7.0/fpm/conf.d/php-custom.ini"
   echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/7.0/fpm/conf.d/opcache.ini"
   echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/7.0/mods-available/xdebug.ini"
-  echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.0/mods-available/mailcatcher.ini"
 
   service php7.0-fpm restart
 }

--- a/php71/provision.sh
+++ b/php71/provision.sh
@@ -150,14 +150,21 @@ configure() {
   cp "${DIR}/php7.1-custom.ini" "/etc/php/7.1/fpm/conf.d/php-custom.ini"
   cp "/srv/config/php-config/opcache.ini" "/etc/php/7.1/fpm/conf.d/opcache.ini"
   cp "/srv/config/php-config/xdebug.ini" "/etc/php/7.1/mods-available/xdebug.ini"
-  cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.1/mods-available/mailcatcher.ini"
+  if [[ -e /srv/config/php-config/mailcatcher.ini ]]; then
+    cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.1/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.1/mods-available/mailcatcher.ini"
+
+  fi
+  if [[ -e /srv/config/php-config/mailhog.ini ]]; then
+    cp "/srv/config/php-config/mailhog.ini" "/etc/php/7.1/mods-available/mailhog.ini"
+    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/7.1/mods-available/mailhog.ini"
+  fi
 
   echo " * Copied ${DIR}/php7.1-fpm.conf                   to /etc/php/7.1/fpm/php-fpm.conf"
   echo " * Copied ${DIR}/php7.1-www.conf                   to /etc/php/7.1/fpm/pool.d/www.conf"
   echo " * Copied ${DIR}/php7.1-custom.ini                 to /etc/php/7.1/fpm/conf.d/php-custom.ini"
   echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/7.1/fpm/conf.d/opcache.ini"
   echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/7.1/mods-available/xdebug.ini"
-  echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.1/mods-available/mailcatcher.ini"
 
   service php7.1-fpm restart
 }

--- a/php72/provision.sh
+++ b/php72/provision.sh
@@ -149,7 +149,15 @@ configure() {
   cp "${DIR}/php7.2-custom.ini" "/etc/php/7.2/fpm/conf.d/php-custom.ini"
   cp "/srv/config/php-config/opcache.ini" "/etc/php/7.2/fpm/conf.d/opcache.ini"
   cp "/srv/config/php-config/xdebug.ini" "/etc/php/7.2/mods-available/xdebug.ini"
-  cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.2/mods-available/mailcatcher.ini"
+  if [[ -e /srv/config/php-config/mailcatcher.ini ]]; then
+    cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.2/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.2/mods-available/mailcatcher.ini"
+
+  fi
+  if [[ -e /srv/config/php-config/mailhog.ini ]]; then
+    cp "/srv/config/php-config/mailhog.ini" "/etc/php/7.2/mods-available/mailhog.ini"
+    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/7.2/mods-available/mailhog.ini"
+  fi
 
   echo " * Copied ${DIR}/php7.2-fpm.conf                   to /etc/php/7.2/fpm/php-fpm.conf"
   echo " * Copied ${DIR}/php7.2-www.conf                   to /etc/php/7.2/fpm/pool.d/www.conf"


### PR DESCRIPTION
fixes a PHP 7.0 typo that overwrote the 7.1 fpm config, and added mailhog support if present