### PR TITLE
Update error log location to /var/log/ for all PHP versions.

### DIFF
--- a/php56/php5.6-custom.ini
+++ b/php56/php5.6-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /srv/log/php5.6_errors.log
+error_log = /var/log/php5.6_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/php70/php7.0-custom.ini
+++ b/php70/php7.0-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /srv/log/php7.0_errors.log
+error_log = /var/log/php7.0_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/php71/php7.1-custom.ini
+++ b/php71/php7.1-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /srv/log/php7.1_errors.log
+error_log = /var/log/php7.1_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/php72/php7.2-custom.ini
+++ b/php72/php7.2-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /srv/log/php7.2_errors.log
+error_log = /var/log/php7.2_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M


### PR DESCRIPTION
Since VVV 2.2.1 the logs location has been moved to /var/log instead of /srv/log.
That has since made all non-default PHP versions log to nginx default file instead if it's dedicated file.

I'm afraid this PR would break for users with VVV < 2.2.1.
Should we maybe create a pre-vvv-2.2.1 branch from the current master and then merge this PR?
That would of course also require a branch change for the utility sources here https://github.com/Varying-Vagrant-Vagrants/VVV/blob/develop/Vagrantfile#L188.