### PR TITLE
first step to back to the original package. 

### DIFF
--- a/memcached-admin/provision.sh
+++ b/memcached-admin/provision.sh
@@ -2,9 +2,9 @@
 # Download and extract phpMemcachedAdmin to provide a dashboard view and
 # admin interface to the goings on of memcached when running
 if [[ ! -d "/srv/www/default/memcached-admin" ]]; then
-	echo -e "\nDownloading phpMemcachedAdmin, see https://github.com/wp-cloud/phpmemcacheadmin"
+	echo -e "\nDownloading phpMemcachedAdmin, see https://github.com/elijaa/phpmemcachedadmin"
 	cd /srv/www/default
-	wget -q -O phpmemcachedadmin.tar.gz "https://github.com/wp-cloud/phpmemcacheadmin/archive/1.2.3.tar.gz"
+	wget -q -O phpmemcachedadmin.tar.gz "https://github.com/wp-cloud/phpmemcacheadmin/archive/1.2.4-vvv.tar.gz"
 	tar -xf phpmemcachedadmin.tar.gz
 	mv phpmemcacheadmin* memcached-admin
 	rm phpmemcachedadmin.tar.gz


### PR DESCRIPTION
1.2.4-vvv is a php7.2 compat version of 1.3.0-upstream

when the `elijaa/phpmemcachedadmin` package tags a new release with php >=7.2 support we can switch over to the repo there.