### PR TITLE
Fix PHP log locations

### DIFF
--- a/php56/php5.6-custom.ini
+++ b/php56/php5.6-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /var/log/php5.6_errors.log
+error_log = /var/log/php/php5.6_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/php56/php5.6-fpm.conf
+++ b/php56/php5.6-fpm.conf
@@ -29,7 +29,7 @@ pid = /var/run/php5.6-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php5.6-fpm.log
+error_log = /var/log/php/php5.6-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/php70/php7.0-custom.ini
+++ b/php70/php7.0-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /var/log/php7.0_errors.log
+error_log = /var/log/php/php7.0_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/php70/php7.0-fpm.conf
+++ b/php70/php7.0-fpm.conf
@@ -29,7 +29,7 @@ pid = /var/run/php7.0-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php7.0-fpm.log
+error_log = /var/log/php/php7.0-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/php71/php7.1-custom.ini
+++ b/php71/php7.1-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /var/log/php7.1_errors.log
+error_log = /var/log/php/php7.1_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/php71/php7.1-fpm.conf
+++ b/php71/php7.1-fpm.conf
@@ -29,7 +29,7 @@ pid = /var/run/php7.1-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php7.1-fpm.log
+error_log = /var/log/php/php7.1-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/php72/php7.2-custom.ini
+++ b/php72/php7.2-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /var/log/php7.2_errors.log
+error_log = /var/log/php/php7.2_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/php72/php7.2-fpm.conf
+++ b/php72/php7.2-fpm.conf
@@ -29,7 +29,7 @@ pid = /var/run/php7.2-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php7.2-fpm.log
+error_log = /var/log/php/php7.2-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities

--- a/php73/php7.3-custom.ini
+++ b/php73/php7.3-custom.ini
@@ -38,7 +38,7 @@ track_errors = Off
 html_errors = 1
 
 ; Log errors to specified file.
-error_log = /var/log/php7.3_errors.log
+error_log = /var/log/php/php7.3_errors.log
 
 ; Maximum size of POST data that PHP will accept.
 post_max_size = 1024M

--- a/php73/php7.3-fpm.conf
+++ b/php73/php7.3-fpm.conf
@@ -29,7 +29,7 @@ pid = /var/run/php7.3-fpm.pid
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php7.3-fpm.log
+error_log = /var/log/php/php7.3-fpm.log
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities


### PR DESCRIPTION
They're using the `/var/log` folder, but that folder isn't shared, instead use `/var/log/php`