### PR TITLE
Update composer in xhgui during provision

### DIFF
--- a/tideways/provision.sh
+++ b/tideways/provision.sh
@@ -71,7 +71,7 @@ install_xhgui() {
         echo -e "\n * Updating xhgui..."
         cd /srv/www/default/xhgui
         git pull --rebase origin master > /dev/null 2>&1
-        sudo php install.php > /dev/null 2>&1
+        sudo composer update > /dev/null 2>&1
     fi
 }
 

--- a/tideways/provision.sh
+++ b/tideways/provision.sh
@@ -71,7 +71,7 @@ install_xhgui() {
         echo -e "\n * Updating xhgui..."
         cd /srv/www/default/xhgui
         git pull --rebase origin master > /dev/null 2>&1
-        sudo composer update > /dev/null 2>&1
+        noroot composer update --prefer-dist > /dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
Looking at the code of xhgui the install.php execute `install` so doesn't involve the update of the dependencies https://github.com/perftools/xhgui/blob/master/install.php#L75