### PR TITLE
🐛 BUG: Error reading values from config with shyaml

### DIFF
--- a/tls-ca/provision.sh
+++ b/tls-ca/provision.sh
@@ -100,12 +100,12 @@ get_sites() {
 }
 
 get_host() {
-    local value=$(shyaml "get-value sites.${1}.hosts.0" 2> /dev/null < ${VVV_CONFIG})
+    local value=$(shyaml get-value sites.${1}.hosts.0 2> /dev/null < ${VVV_CONFIG})
     echo "${value:-$@}"
 }
 
 get_hosts() {
-    local value=$(shyaml "get-values sites.${1}.hosts" 2> /dev/null < ${VVV_CONFIG})
+    local value=$(shyaml get-values sites.${1}.hosts 2> /dev/null < ${VVV_CONFIG})
     echo "${value:-$@}"
 }
 


### PR DESCRIPTION
The change from `cat` to `shyaml` broke with the quotes included, which in turn broke  the SANs for the self-signed certificate.