### PR TITLE
fix super user root warning when provisioning webgrind

### DIFF
--- a/webgrind/provision.sh
+++ b/webgrind/provision.sh
@@ -3,8 +3,12 @@
 # xdebug profiler)
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+noroot() {
+  sudo -EH -u "vagrant" "$@";
+}
+
 # make sure the folder exists and is writable
-mkdir -p /srv/www/default/webgrind/
+noroot mkdir -p /srv/www/default/webgrind/
 
 # cleanup .git folder from pre-composer days
 if [ -d "/srv/www/default/webgrind/.git" ]; then
@@ -13,6 +17,8 @@ if [ -d "/srv/www/default/webgrind/.git" ]; then
 fi
 
 # phpMyAdmin
-echo -e " * Installing/Updating webgrind, see https://github.com/jokkedk/webgrind ..."
+echo " * Installing/Updating webgrind, see https://github.com/jokkedk/webgrind ..."
 cd "${DIR}"
-composer update --no-autoloader
+noroot composer update --no-autoloader
+
+echo " * Finished webgrind provisioner"


### PR DESCRIPTION
This fixes composer running under the root super user during provisioning webgrind