### PR TITLE
MongoDB - Fix incorrect package name

### DIFF
--- a/mongodb/provision.sh
+++ b/mongodb/provision.sh
@@ -43,7 +43,7 @@ install_mongodb() {
     apt-get -y update
     echo " * Installing apt-get packages"
     apt_package_install_list=(
-        mongodb-org,
+        mongodb-org
         re2c
     )
     if ! apt-get -y --allow-downgrades --allow-remove-essential --allow-change-held-packages -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew install --fix-missing --fix-broken ${apt_package_install_list[@]}; then


### PR DESCRIPTION
This fixes error: `Unable to locate package mongodb-org,`
