### PR TITLE
TLS-CA bash functions

### DIFF
--- a/tls-ca/openssl-default-cert.conf
+++ b/tls-ca/openssl-default-cert.conf
@@ -1,0 +1,13 @@
+authorityKeyIdentifier = keyid,issuer
+basicConstraints       = CA:FALSE
+keyUsage               = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+extendedKeyUsage       = serverAuth, clientAuth
+subjectAltName         = @alt_names
+
+[alt_names]
+DNS.1 = vvv.test
+DNS.2 = *.vvv.test
+DNS.3 = vvv.local
+DNS.4 = *.vvv.local
+DNS.5 = vvv
+DNS.6 = *.vvv

--- a/tls-ca/openssl-site-stub.conf
+++ b/tls-ca/openssl-site-stub.conf
@@ -1,0 +1,7 @@
+authorityKeyIdentifier = keyid,issuer
+basicConstraints       = CA:FALSE
+keyUsage               = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+extendedKeyUsage       = serverAuth, clientAuth
+subjectAltName         = @alt_names
+
+[alt_names]

--- a/tls-ca/provision.sh
+++ b/tls-ca/provision.sh
@@ -6,100 +6,23 @@ if [[ -f /vagrant/config.yml ]]; then
 	VVV_CONFIG=/vagrant/config.yml
 fi
 
+codename=$(lsb_release --codename | cut -f2)
+CERTIFICATES_DIR="/srv/certificates"
+if [[ $codename == "trusty" ]]; then # VVV 2 uses Ubuntu 14 LTS trusty
+    echo " ! WARNING: Unsupported Ubuntu 14 detected! Switching certificate folder, please upgrade to VVV 3+"
+    CERTIFICATES_DIR="/vagrant/certificates"
+fi
+
+DEFAULT_CERT_DIR="${CERTIFICATES_DIR}/default"
+CA_DIR="${CERTIFICATES_DIR}/ca"
+ROOT_CA_DAYS=397 # MacOS/Apple won't accept Root CA's that last longer than this
+SITE_CERTIFICATE_DAYS=200
+
+# Fix a bug that happens if you run the provisioner sometimes
 if [[ ! -e ~/.rnd ]]; then
     echo " * Generating Random Number for cert generation..."
     openssl rand -out ~/.rnd -hex 256 2>&1
 fi
-
-codename=$(lsb_release --codename | cut -f2)
-CERTIFICATES_DIR="/srv/certificates"
-if [[ $codename == "trusty" ]]; then # VVV 2 uses Ubuntu 14 LTS trusty
-    echo " ! Unsupported Ubuntu 14 detected! Switching certificate folder, please upgrade to VVV 3+"
-    CERTIFICATES_DIR="/vagrant/certificates"
-fi
-
-CA_DIR="${CERTIFICATES_DIR}/ca"
-
-if [ ! -d "${CA_DIR}" ];then
-    echo " * Setting up VVV Certificate Authority"
-    mkdir -p "${CA_DIR}"
-
-    openssl genrsa \
-        -out "${CA_DIR}/ca.key" \
-        2048 &>/dev/null
-
-    openssl req \
-        -x509 -new \
-        -nodes \
-        -key "${CA_DIR}/ca.key" \
-        -sha256 \
-        -days 397 \
-        -config "${DIR}/openssl-ca.conf" \
-        -out "${CA_DIR}/ca.crt"
-fi
-
-mkdir -p /usr/share/ca-certificates/vvv
-if [[ ! -f /usr/share/ca-certificates/vvv/ca.crt ]]; then
-    echo " * Adding root certificate to the VM"
-    cp -f "${CA_DIR}/ca.crt" /usr/share/ca-certificates/vvv/ca.crt
-    echo " * Updating loaded VM certificates"
-    update-ca-certificates --fresh
-fi
-
-echo " * Setting up default Certificate for vvv.test and vvv.local"
-
-DEFAULT_CERT_DIR="${CERTIFICATES_DIR}/default"
-
-rm -rf "${DEFAULT_CERT_DIR}"
-mkdir -p "${DEFAULT_CERT_DIR}"
-
-cat << EOF > "${DEFAULT_CERT_DIR}/openssl.conf"
-authorityKeyIdentifier = keyid,issuer
-basicConstraints       = CA:FALSE
-keyUsage               = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-extendedKeyUsage       = serverAuth, clientAuth
-subjectAltName         = @alt_names
-
-[alt_names]
-DNS.1 = vvv.test
-DNS.2 = *.vvv.test
-DNS.3 = vvv.local
-DNS.4 = *.vvv.local
-DNS.5 = vvv
-DNS.6 = *.vvv
-EOF
-
-openssl genrsa \
-    -out "${DEFAULT_CERT_DIR}/dev.key" \
-    2048 &>/dev/null
-
-openssl req \
-    -new \
-    -key "${DEFAULT_CERT_DIR}/dev.key" \
-    -out "${DEFAULT_CERT_DIR}/dev.csr" \
-    -subj "/CN=vvv.test/C=GB/ST=Test Province/L=Test Locality/O=VVV/OU=VVV" &>/dev/null
-
-openssl x509 \
-    -req \
-    -in "${DEFAULT_CERT_DIR}/dev.csr" \
-    -CA "${CA_DIR}/ca.crt" \
-    -CAkey "${CA_DIR}/ca.key" \
-    -CAcreateserial \
-    -out "${DEFAULT_CERT_DIR}/dev.crt" \
-    -days 200 \
-    -sha256 \
-    -extfile "${DEFAULT_CERT_DIR}/openssl.conf" &>/dev/null
-
-echo " * Symlinking default server certificate and key"
-
-rm -rf /etc/nginx/server-2.1.0.crt
-rm -rf /etc/nginx/server-2.1.0.key
-
-echo " * Symlinking ${DEFAULT_CERT_DIR}/dev.crt to /etc/nginx/server-2.1.0.crt"
-ln -s "${DEFAULT_CERT_DIR}/dev.crt" /etc/nginx/server-2.1.0.crt
-
-echo " * Symlinking ${DEFAULT_CERT_DIR}/dev.key to /etc/nginx/server-2.1.0.key"
-ln -s "${DEFAULT_CERT_DIR}/dev.key" /etc/nginx/server-2.1.0.key
 
 get_sites() {
     local value=$(shyaml keys sites 2> /dev/null < ${VVV_CONFIG})
@@ -116,8 +39,80 @@ get_hosts() {
     echo "${value:-$@}"
 }
 
-echo " * Generating Site certificates"
-for SITE in $(get_sites); do
+install_root_certificate() {
+    mkdir -p /usr/share/ca-certificates/vvv
+    if [[ ! -f /usr/share/ca-certificates/vvv/ca.crt ]]; then
+        echo " * Adding root certificate to the VM"
+        cp -f "${CA_DIR}/ca.crt" /usr/share/ca-certificates/vvv/ca.crt
+        echo " * Updating loaded VM certificates"
+        update-ca-certificates --fresh
+    fi
+}
+
+create_root_certificate() {
+
+    if [ ! -d "${CA_DIR}" ]; then
+        echo " * Setting up VVV Certificate Authority"
+        mkdir -p "${CA_DIR}"
+
+        openssl genrsa \
+            -out "${CA_DIR}/ca.key" \
+            2048 &>/dev/null
+
+        openssl req \
+            -x509 -new \
+            -nodes \
+            -key "${CA_DIR}/ca.key" \
+            -sha256 \
+            -days $ROOT_CA_DAYS \
+            -config "${DIR}/openssl-ca.conf" \
+            -out "${CA_DIR}/ca.crt"
+    fi
+}
+
+create_default_certificate() {
+    echo " * Setting up default Certificate for vvv.test and vvv.local"
+
+    rm -rf "${DEFAULT_CERT_DIR}"
+    mkdir -p "${DEFAULT_CERT_DIR}"
+
+    openssl genrsa \
+        -out "${DEFAULT_CERT_DIR}/dev.key" \
+        2048 &>/dev/null
+
+    openssl req \
+        -new \
+        -key "${DEFAULT_CERT_DIR}/dev.key" \
+        -out "${DEFAULT_CERT_DIR}/dev.csr" \
+        -subj "/CN=vvv.test/C=GB/ST=Test Province/L=Test Locality/O=VVV/OU=VVV" &>/dev/null
+
+    openssl x509 \
+        -req \
+        -in "${DEFAULT_CERT_DIR}/dev.csr" \
+        -CA "${CA_DIR}/ca.crt" \
+        -CAkey "${CA_DIR}/ca.key" \
+        -CAcreateserial \
+        -out "${DEFAULT_CERT_DIR}/dev.crt" \
+        -days $SITE_CERTIFICATE_DAYS \
+        -sha256 \
+        -extfile "${DIR}/openssl-default-cert.conf"
+}
+
+install_default_certificate() {
+    echo " * Symlinking default server certificate and key"
+
+    rm -rf /etc/nginx/server-2.1.0.crt
+    rm -rf /etc/nginx/server-2.1.0.key
+
+    echo " * Symlinking ${DEFAULT_CERT_DIR}/dev.crt to /etc/nginx/server-2.1.0.crt"
+    ln -s "${DEFAULT_CERT_DIR}/dev.crt" /etc/nginx/server-2.1.0.crt
+
+    echo " * Symlinking ${DEFAULT_CERT_DIR}/dev.key to /etc/nginx/server-2.1.0.key"
+    ln -s "${DEFAULT_CERT_DIR}/dev.key" /etc/nginx/server-2.1.0.key
+}
+
+regenerate_site_certificate() {
+    SITE=${1}
     echo " * Generating certificates for the '${SITE}' hosts"
     SITE_ESCAPED="${SITE//./\\.}"
     COMMON_NAME=$(get_host "${SITE_ESCAPED}")
@@ -127,15 +122,9 @@ for SITE in $(get_sites); do
     rm -rf "${SITE_CERT_DIR}"
     mkdir -p "${SITE_CERT_DIR}"
 
-    cat << EOF > "${SITE_CERT_DIR}/openssl.conf"
-authorityKeyIdentifier = keyid,issuer
-basicConstraints       = CA:FALSE
-keyUsage               = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-extendedKeyUsage       = serverAuth, clientAuth
-subjectAltName         = @alt_names
+    # Copy over the site conf stub then append the domains
+    cp -f "${DIR}/openssl-site-stub.conf" "${SITE_CERT_DIR}/openssl.conf"
 
-[alt_names]
-EOF
     I=0
     for DOMAIN in ${HOSTS}; do
         ((I++))
@@ -164,7 +153,20 @@ EOF
         -days 200 \
         -sha256 \
         -extfile "${SITE_CERT_DIR}/openssl.conf" &>/dev/null
-done
+}
 
+process_site_certificates() {
+    echo " * Generating site certificates"
+    for SITE in $(get_sites); do
+        regenerate_site_certificate $SITE
+    done
+    echo " * Finished generating site certificates"
+}
+
+create_root_certificate
+install_root_certificate
+create_default_certificate
+install_default_certificate
+process_site_certificates
 
 echo " * Finished generating TLS certificates"


### PR DESCRIPTION
refactored the TLS CA to use bash functions for everything, set the certificate expiry days as variables, and moved the openssl config stuff to files

Recreates some of what was in #56, this should work the same as before, but structured better