### PR TITLE
minor refactors to the tideways provisioner

### DIFF
--- a/tideways/provision.sh
+++ b/tideways/provision.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tideways with XHgui
+# Tideways with XHGui
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 function install_tideways() {
@@ -15,7 +15,7 @@ function install_tideways() {
 function install_tideways_for_php_version() {
     version=$1
     echo " * Installing Tideways for PHP ${version}"
-    php_modules_path=$(php-config$version --extension-dir)
+    php_modules_path=$("php-config${version}" --extension-dir)
     echo " * Copying tideways files for PHP ${version}"
     cp -f "${DIR}/tideways.ini" "/etc/php/${version}/mods-available/tideways_xhprof.ini"
     cp -f "${DIR}/xhgui-php.ini" "/etc/php/${version}/mods-available/xhgui.ini"
@@ -28,7 +28,7 @@ function install_tideways_for_php_version() {
         update-alternatives --set php "/usr/bin/php${version}" > /dev/null 2>&1
         update-alternatives --set php-config "/usr/bin/php-config${version}" > /dev/null 2>&1
         update-alternatives --set phpize "/usr/bin/phpize${version}" > /dev/null 2>&1
-        phpize$version > /dev/null 2>&1
+        "phpize${version}" > /dev/null 2>&1
         
         # configure and build
         ./configure --enable-tideways-xhprof --with-php-config="php-config${version}" > /dev/null 2>&1

--- a/tideways/provision.sh
+++ b/tideways/provision.sh
@@ -2,7 +2,7 @@
 # Tideways with XHgui
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-install_tideways() {
+function install_tideways() {
     if [[ ! -d /var/local/tideways-php/.git ]]; then
         echo " * Cloning Tideways extension"
         git clone "https://github.com/tideways/php-xhprof-extension" /var/local/tideways-php
@@ -12,39 +12,49 @@ install_tideways() {
     fi
 }
 
-install_tideways_php() {
-    echo " * Installing Tideways for PHP $version"
+function install_tideways_for_php_version() {
+    version=$1
+    echo " * Installing Tideways for PHP ${version}"
+    php_modules_path=$(php-config$version --extension-dir)
+    echo " * Copying tideways files for PHP ${version}"
+    cp -f "${DIR}/tideways.ini" "/etc/php/${version}/mods-available/tideways_xhprof.ini"
+    cp -f "${DIR}/xhgui-php.ini" "/etc/php/${version}/mods-available/xhgui.ini"
+    if [[ ! -f "${php_modules_path}/tideways_xhprof.so" ]] || [[ $(stat -c %Y "${php_modules_path}/tideways_xhprof.so") -lt $(stat -c %Y "/var/local/tideways-php/.git/info/") ]]; then
+        echo " * Compiling Tideways for PHP ${version}"
+        cp -rf /var/local/tideways-php "/var/local/tideways-php${version}"
+        cd "/var/local/tideways-php${version}"
+
+        # switch to PHP version we're building for
+        update-alternatives --set php "/usr/bin/php${version}" > /dev/null 2>&1
+        update-alternatives --set php-config "/usr/bin/php-config${version}" > /dev/null 2>&1
+        update-alternatives --set phpize "/usr/bin/phpize${version}" > /dev/null 2>&1
+        phpize$version > /dev/null 2>&1
+        
+        # configure and build
+        ./configure --enable-tideways-xhprof --with-php-config="php-config${version}" > /dev/null 2>&1
+        make > /dev/null 2>&1
+        make install > /dev/null 2>&1
+        
+        # perform cleanup
+        cd "${DIR}"
+        rm -rf "/var/local/tideways-php${version}"
+    fi
+    phpenmod -v "$version" tideways_xhprof
+    phpenmod -v "$version" xhgui
+}
+
+function check_tideways_php() {
     cp -f "${DIR}/tideways-header.php" "/srv/tideways-header.php"
     # Tideways is only for php =>7.0
     for version in "7.0" "7.1" "7.2" "7.3" "7.4"
     do
         if [[ $(command -v php$version) ]]; then
-            php_modules_path=$(php-config$version --extension-dir)
-            echo " * Copying tideways files for PHP ${version}"
-            cp -f "${DIR}/tideways.ini" "/etc/php/${version}/mods-available/tideways_xhprof.ini"
-            cp -f "${DIR}/xhgui-php.ini" "/etc/php/${version}/mods-available/xhgui.ini"
-            if [[ ! -f "${php_modules_path}/tideways_xhprof.so" ]] || [[ $(stat -c %Y "${php_modules_path}/tideways_xhprof.so") -lt $(stat -c %Y "/var/local/tideways-php/.git/info/") ]]; then
-                echo " * Compiling Tideways for PHP ${version}"
-                cp -rf /var/local/tideways-php "/var/local/tideways-php${version}"
-                cd "/var/local/tideways-php${version}"
-                update-alternatives --set php "/usr/bin/php${version}" > /dev/null 2>&1
-                update-alternatives --set php-config "/usr/bin/php-config${version}" > /dev/null 2>&1
-                update-alternatives --set phpize "/usr/bin/phpize${version}" > /dev/null 2>&1
-                phpize$version > /dev/null 2>&1
-                ./configure --enable-tideways-xhprof --with-php-config="php-config${version}" > /dev/null 2>&1
-                make > /dev/null 2>&1
-                make install > /dev/null 2>&1
-                cd "${DIR}"
-                rm -rf "/var/local/tideways-php${version}"
-            fi
-            phpenmod -v "$version" tideways_xhprof
-            phpenmod -v "$version" xhgui
-
+            install_tideways_for_php_version "${version}"
         fi
     done
 }
 
-restart_php() {
+function restart_php() {
     echo " * Restarting PHP-FPM server"
     for version in "7.0" "7.1" "7.2" "7.3" "7.4"
     do
@@ -56,7 +66,8 @@ restart_php() {
     service nginx restart > /dev/null 2>&1
 }
 
-install_xhgui() {
+function install_xhgui_frontend() {
+    cp -f "${DIR}/nginx.conf" "/etc/nginx/custom-utilities/xhgui.conf"
     if [[ ! -d "/srv/www/default/xhgui" ]]; then
         echo -e " * Git cloning xhgui from https://github.com/perftools/xhgui.git"
         cd /srv/www/default
@@ -75,7 +86,7 @@ install_xhgui() {
     fi
 }
 
-enable_tideways_by_site() {
+function enable_tideways_by_site() {
     echo " * Tideways-by-site started"
 
     VVV_CONFIG=/vagrant/vvv-custom.yml
@@ -89,13 +100,11 @@ enable_tideways_by_site() {
 
 . "${DIR}/../mongodb/provision.sh"
 
-echo " * Installing Tideways & XHgui"
-DIR=$(dirname "$0")
+echo " * Installing Tideways & XHGui"
 install_tideways
-install_tideways_php
-install_xhgui
-cp -f "${DIR}/nginx.conf" "/etc/nginx/custom-utilities/xhgui.conf"
+check_tideways_php
+install_xhgui_frontend
 enable_tideways_by_site
 restart_php
 
-echo " * Tideways and xhgui installed"
+echo " * Tideways and XHGui installed"


### PR DESCRIPTION
Moves compiling for PHP around a bit

As an aside, we need to set the default PHP back to the default at the end, otherwise when it builds tideways it'll end up on the most recently installed version of PHP

Perhaps VVV core can set the default in the post provision trigger too