### PR TITLE
Bail in the Tideways header if the module isn't loaded.

### DIFF
--- a/tideways/tideways-header.php
+++ b/tideways/tideways-header.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! extension_loaded( 'tideways_xhprof' ) ) {
+    return;
+}
+
 // don't run on CLI
 if ( empty($_SERVER['REMOTE_ADDR']) and !isset($_SERVER['HTTP_USER_AGENT']) and count($_SERVER['argv']) > 0) {
     return;


### PR DESCRIPTION
Running VVV without any debug modules loaded resulted in this error on every WP page load:

https://github.com/laynefyc/xhgui-branch/blob/master/external/header.php#L58

This PR seeks to check if the Tideways module is loaded before requiring the aforementioned file.

**To test:**
- Turn off debug modules in your VVV (using `tideways_off`)
- Load a WordPress site from VVV
- Verify there is no PHP error logged about xhgui