### PR TITLE
Fix tideways provision after #61

### DIFF
--- a/tideways/provision.sh
+++ b/tideways/provision.sh
@@ -99,7 +99,8 @@ function enable_tideways_by_site() {
 }
 
 . "${DIR}/../mongodb/provision.sh"
-DIR=$(dirname "$0")
+# Set DIR back to undo the DIR set in the MongoDB provisioner
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo " * Installing Tideways & XHGui"
 install_tideways
 check_tideways_php

--- a/tideways/provision.sh
+++ b/tideways/provision.sh
@@ -99,7 +99,7 @@ function enable_tideways_by_site() {
 }
 
 . "${DIR}/../mongodb/provision.sh"
-
+DIR=$(dirname "$0")
 echo " * Installing Tideways & XHGui"
 install_tideways
 check_tideways_php


### PR DESCRIPTION
Otherwise
```
    default: cp: 
    default: cannot stat '/srv/provision/utilities/core/mongodb/tideways-header.php'
    default: : No such file or directory
    default: cp: 
    default: cannot stat '/srv/provision/utilities/core/mongodb/tideways.ini'
    default: : No such file or directory
    default: cp: 
    default: cannot stat '/srv/provision/utilities/core/mongodb/xhgui-php.ini'
    default: : No such file or directory
    default: cp: 
    default: cannot stat '/srv/provision/utilities/core/mongodb/tideways.ini'
    default: : No such file or directory
    default: cp: 
    default: cannot stat '/srv/provision/utilities/core/mongodb/xhgui-php.ini'
    default: : No such file or directory
    default: cp: 
    default: cannot stat '/srv/provision/utilities/core/mongodb/nginx.conf'
```