### PR TITLE
Remove php8.0-json from php80/provision.sh

### DIFF
--- a/php80/provision.sh
+++ b/php80/provision.sh
@@ -34,7 +34,6 @@ apt_package_install_list=(
   "php${PHPVERSION}-mbstring"
   "php${PHPVERSION}-mysql"
   "php${PHPVERSION}-imap"
-  "php${PHPVERSION}-json"
   "php${PHPVERSION}-soap"
   "php${PHPVERSION}-xml"
   "php${PHPVERSION}-zip"


### PR DESCRIPTION
This PR removes `php8.0-json` from the list of packages installed by php80/provision.sh. In PHP 8.0, `ext-json` is always available. I'm guessing that is why there is no `php8.0-json` package. The first time that I tried to provision php80 in my vvv install I got the following error:

```
$ vagrant provision --provision-with utility-core-php80
(...)
==> default: Running provisioner: utility-core-php80 (shell)...
    default: Running: /tmp/vagrant-shell20201016-18935-5ekxp.sh
    default:  ▷ Running the 'utility-core-php80' provisioner...
    default: E: Package 'php8.0-json' has no installation candidate
    default: cp: cannot create regular file '/etc/php/8.0/fpm/php-fpm.conf': No such file or directory
    default: cp: cannot create regular file '/etc/php/8.0/fpm/pool.d/www.conf': No such file or directory
    default: cp: cannot create regular file '/etc/php/8.0/fpm/conf.d/php-custom.ini': No such file or directory
    default: cp: cannot create regular file '/etc/php/8.0/fpm/conf.d/opcache.ini': No such file or directory
    default: Failed to restart php8.0-fpm.service: Unit php8.0-fpm.service not found.
    default:  ✔ The 'utility-core-php80' provisioner completed in 4 seconds.
```

After removing `php8.0-json`, I could succesfully run a site using PHP 8.0 in my vvv install.

Related to #68 

cc @tomjn 