### PR TITLE
Force creation of symlink

### DIFF
--- a/opcache-gui/provision.sh
+++ b/opcache-gui/provision.sh
@@ -8,6 +8,6 @@ noroot composer require amnuts/opcache-gui
 
 echo " * symlinking index.php"
 
-noroot ln -s ./vendor/amnuts/opcache-gui/index.php ./index.php
+noroot ln -sf ./vendor/amnuts/opcache-gui/index.php ./index.php
 
 echo " * Opcache GUI complete"


### PR DESCRIPTION
In this way in the log we don't have this output, it is forcing the creation every time and keep constistency with other utilities:

```
    default: ln: 
    default: failed to create symbolic link './index.php'
    default: : File exists
```