### PR TITLE
Fix/default php hardcoding

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -2,4 +2,4 @@
 engines:
  phpcs:
    enabled: true
-   php_version: 7.2
+   php_version: 7.3

--- a/php56/provision.sh
+++ b/php56/provision.sh
@@ -3,6 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # PACKAGE INSTALLATION
+DEFAULTPHP=$(php -r "echo substr(phpversion(),0,3);")
 PHPVERSION="5.6"
 
 apt_package_install_list=(
@@ -102,11 +103,11 @@ configure() {
 package_install
 configure
 
-echo " * Restoring the default PHP CLI version"
-update-alternatives --set php /usr/bin/php7.2
-update-alternatives --set phar /usr/bin/phar7.2
-update-alternatives --set phar.phar /usr/bin/phar.phar7.2
-update-alternatives --set phpize /usr/bin/phpize7.2
-update-alternatives --set php-config /usr/bin/php-config7.2
+echo " * Restoring the default PHP CLI version ( ${DEFAULTPHP} )"
+update-alternatives --set php "/usr/bin/php${DEFAULTPHP}"
+update-alternatives --set phar "/usr/bin/phar${DEFAULTPHP}"
+update-alternatives --set phar.phar "/usr/bin/phar.phar${DEFAULTPHP}"
+update-alternatives --set phpize "/usr/bin/phpize${DEFAULTPHP}"
+update-alternatives --set php-config "/usr/bin/php-config${DEFAULTPHP}"
 
 echo " * PHP ${PHPVERSION} provisioning complete"

--- a/php70/provision.sh
+++ b/php70/provision.sh
@@ -3,7 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # PACKAGE INSTALLATION
-
+DEFAULTPHP=$(php -r "echo substr(phpversion(),0,3);")
 PHPVERSION="7.0"
 
 apt_package_install_list=(
@@ -73,43 +73,43 @@ configure() {
   echo " * Copied ${DIR}/php7.0-upstream.conf              to /etc/nginx/upstreams/php70.conf"
 
   # Copy php-fpm configuration from local
-  cp -f "${DIR}/php7.0-fpm.conf" "/etc/php/7.0/fpm/php-fpm.conf"
-  echo " * Copied ${DIR}/php7.0-fpm.conf                   to /etc/php/7.0/fpm/php-fpm.conf"
+  cp -f "${DIR}/php7.0-fpm.conf" "/etc/php/${PHPVERSION}/fpm/php-fpm.conf"
+  echo " * Copied ${DIR}/php7.0-fpm.conf                   to /etc/php/${PHPVERSION}/fpm/php-fpm.conf"
 
-  cp -f "${DIR}/php7.0-www.conf" "/etc/php/7.0/fpm/pool.d/www.conf"
-  echo " * Copied ${DIR}/php7.0-www.conf                   to /etc/php/7.0/fpm/pool.d/www.conf"
+  cp -f "${DIR}/php7.0-www.conf" "/etc/php/${PHPVERSION}/fpm/pool.d/www.conf"
+  echo " * Copied ${DIR}/php7.0-www.conf                   to /etc/php/${PHPVERSION}/fpm/pool.d/www.conf"
 
-  cp -f "${DIR}/php7.0-custom.ini" "/etc/php/7.0/fpm/conf.d/php-custom.ini"
-  echo " * Copied ${DIR}/php7.0-custom.ini                 to /etc/php/7.0/fpm/conf.d/php-custom.ini"
+  cp -f "${DIR}/php7.0-custom.ini" "/etc/php/${PHPVERSION}/fpm/conf.d/php-custom.ini"
+  echo " * Copied ${DIR}/php7.0-custom.ini                 to /etc/php/${PHPVERSION}/fpm/conf.d/php-custom.ini"
 
-  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/7.0/fpm/conf.d/opcache.ini"
-  echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/7.0/fpm/conf.d/opcache.ini"
+  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/${PHPVERSION}/fpm/conf.d/opcache.ini"
+  echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/${PHPVERSION}/fpm/conf.d/opcache.ini"
 
-  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/7.0/mods-available/xdebug.ini"
-  echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/7.0/mods-available/xdebug.ini"
+  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/${PHPVERSION}/mods-available/xdebug.ini"
+  echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/${PHPVERSION}/mods-available/xdebug.ini"
 
   if [[ -e /srv/config/php-config/mailcatcher.ini ]]; then
-    cp -f "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.0/mods-available/mailcatcher.ini"
-    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.0/mods-available/mailcatcher.ini"
+    cp -f "/srv/config/php-config/mailcatcher.ini" "/etc/php/${PHPVERSION}/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/${PHPVERSION}/mods-available/mailcatcher.ini"
 
   fi
   if [[ -e /srv/config/php-config/mailhog.ini ]]; then
-    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/7.0/mods-available/mailhog.ini"
-    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/7.0/mods-available/mailhog.ini"
+    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/${PHPVERSION}/mods-available/mailhog.ini"
+    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/${PHPVERSION}/mods-available/mailhog.ini"
   fi
 
-  echo " * Restarting php7.0-fpm"
-  service php7.0-fpm restart
+  echo " * Restarting php${PHPVERSION}-fpm service "
+  service "php${PHPVERSION}-fpm" restart
 }
 
 package_install
 configure
 
-echo " * Restoring the default PHP CLI version"
-update-alternatives --set php /usr/bin/php7.2
-update-alternatives --set phar /usr/bin/phar7.2
-update-alternatives --set phar.phar /usr/bin/phar.phar7.2
-update-alternatives --set phpize /usr/bin/phpize7.2
-update-alternatives --set php-config /usr/bin/php-config7.2
+echo " * Restoring the default PHP CLI version ( ${DEFAULTPHP} )"
+update-alternatives --set php "/usr/bin/php${DEFAULTPHP}"
+update-alternatives --set phar "/usr/bin/phar${DEFAULTPHP}"
+update-alternatives --set phar.phar "/usr/bin/phar.phar${DEFAULTPHP}"
+update-alternatives --set phpize "/usr/bin/phpize${DEFAULTPHP}"
+update-alternatives --set php-config "/usr/bin/php-config${DEFAULTPHP}"
 
 echo " * PHP 7.0 provisioning complete"

--- a/php71/provision.sh
+++ b/php71/provision.sh
@@ -105,11 +105,11 @@ configure() {
 package_install
 configure
 
-echo " * Restoring the default PHP CLI version"
-update-alternatives --set php /usr/bin/php7.2
-update-alternatives --set phar /usr/bin/phar7.2
-update-alternatives --set phar.phar /usr/bin/phar.phar7.2
-update-alternatives --set phpize /usr/bin/phpize7.2
-update-alternatives --set php-config /usr/bin/php-config7.2
+echo " * Restoring the default PHP CLI version ( ${DEFAULTPHP} )"
+update-alternatives --set php "/usr/bin/php${DEFAULTPHP}"
+update-alternatives --set phar "/usr/bin/phar${DEFAULTPHP}"
+update-alternatives --set phar.phar "/usr/bin/phar.phar${DEFAULTPHP}"
+update-alternatives --set phpize "/usr/bin/phpize${DEFAULTPHP}"
+update-alternatives --set php-config "/usr/bin/php-config${DEFAULTPHP}"
 
 echo "PHP 7.1 provisioning complete"

--- a/php71/provision.sh
+++ b/php71/provision.sh
@@ -3,7 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # PACKAGE INSTALLATION
-
+DEFAULTPHP=$(php -r "echo substr(phpversion(),0,3);")
 PHPVERSION="7.1"
 
 apt_package_install_list=(
@@ -73,33 +73,33 @@ configure() {
   echo " * Copied ${DIR}/php7.1-upstream.conf              to /etc/nginx/upstreams/php71.conf"
 
   # Copy php-fpm configuration from local
-  cp -f "${DIR}/php7.1-fpm.conf" "/etc/php/7.1/fpm/php-fpm.conf"
-  echo " * Copied ${DIR}/php7.1-fpm.conf                   to /etc/php/7.1/fpm/php-fpm.conf"
+  cp -f "${DIR}/php7.1-fpm.conf" "/etc/php/${PHPVERSION}/fpm/php-fpm.conf"
+  echo " * Copied ${DIR}/php7.1-fpm.conf                   to /etc/php/${PHPVERSION}/fpm/php-fpm.conf"
 
-  cp -f "${DIR}/php7.1-www.conf" "/etc/php/7.1/fpm/pool.d/www.conf"
-  echo " * Copied ${DIR}/php7.1-www.conf                   to /etc/php/7.1/fpm/pool.d/www.conf"
+  cp -f "${DIR}/php7.1-www.conf" "/etc/php/${PHPVERSION}/fpm/pool.d/www.conf"
+  echo " * Copied ${DIR}/php7.1-www.conf                   to /etc/php/${PHPVERSION}/fpm/pool.d/www.conf"
 
-  cp -f "${DIR}/php7.1-custom.ini" "/etc/php/7.1/fpm/conf.d/php-custom.ini"
-  echo " * Copied ${DIR}/php7.1-custom.ini                 to /etc/php/7.1/fpm/conf.d/php-custom.ini"
+  cp -f "${DIR}/php7.1-custom.ini" "/etc/php/${PHPVERSION}/fpm/conf.d/php-custom.ini"
+  echo " * Copied ${DIR}/php7.1-custom.ini                 to /etc/php/${PHPVERSION}/fpm/conf.d/php-custom.ini"
 
-  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/7.1/fpm/conf.d/opcache.ini"
-  echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/7.1/fpm/conf.d/opcache.ini"
+  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/${PHPVERSION}/fpm/conf.d/opcache.ini"
+  echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/${PHPVERSION}/fpm/conf.d/opcache.ini"
 
-  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/7.1/mods-available/xdebug.ini"
-  echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/7.1/mods-available/xdebug.ini"
+  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/${PHPVERSION}/mods-available/xdebug.ini"
+  echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/${PHPVERSION}/mods-available/xdebug.ini"
 
   if [[ -e /srv/config/php-config/mailcatcher.ini ]]; then
-    cp -f "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.1/mods-available/mailcatcher.ini"
-    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.1/mods-available/mailcatcher.ini"
+    cp -f "/srv/config/php-config/mailcatcher.ini" "/etc/php/${PHPVERSION}/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/${PHPVERSION}/mods-available/mailcatcher.ini"
 
   fi
   if [[ -e /srv/config/php-config/mailhog.ini ]]; then
-    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/7.1/mods-available/mailhog.ini"
-    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/7.1/mods-available/mailhog.ini"
+    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/${PHPVERSION}/mods-available/mailhog.ini"
+    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/${PHPVERSION}/mods-available/mailhog.ini"
   fi
 
-  echo " * Restarting php7.1-fpm service "
-  service php7.1-fpm restart
+  echo " * Restarting php${PHPVERSION}-fpm service "
+  service "php${PHPVERSION}-fpm" restart
 }
 
 package_install

--- a/php72/provision.sh
+++ b/php72/provision.sh
@@ -3,7 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # PACKAGE INSTALLATION
-
+DEFAULTPHP=$(php -r "echo substr(phpversion(),0,3);")
 PHPVERSION="7.2"
 
 apt_package_install_list=(
@@ -72,36 +72,43 @@ configure() {
   echo " * Copied ${DIR}/php7.2-upstream.conf              to /etc/nginx/upstreams/php72.conf"
 
   # Copy php-fpm configuration from local
-  cp -f "${DIR}/php7.2-fpm.conf" "/etc/php/7.2/fpm/php-fpm.conf"
-  echo " * Copied ${DIR}/php7.2-fpm.conf                   to /etc/php/7.2/fpm/php-fpm.conf"
+  cp -f "${DIR}/php7.2-fpm.conf" "/etc/php/${PHPVERSION}/fpm/php-fpm.conf"
+  echo " * Copied ${DIR}/php7.2-fpm.conf                   to /etc/php/${PHPVERSION}/fpm/php-fpm.conf"
 
-  cp -f "${DIR}/php7.2-www.conf" "/etc/php/7.2/fpm/pool.d/www.conf"
-  echo " * Copied ${DIR}/php7.2-www.conf                   to /etc/php/7.2/fpm/pool.d/www.conf"
+  cp -f "${DIR}/php7.2-www.conf" "/etc/php/${PHPVERSION}/fpm/pool.d/www.conf"
+  echo " * Copied ${DIR}/php7.2-www.conf                   to /etc/php/${PHPVERSION}/fpm/pool.d/www.conf"
 
-  cp -f "${DIR}/php7.2-custom.ini" "/etc/php/7.2/fpm/conf.d/php-custom.ini"
-  echo " * Copied ${DIR}/php7.2-custom.ini                 to /etc/php/7.2/fpm/conf.d/php-custom.ini"
+  cp -f "${DIR}/php7.2-custom.ini" "/etc/php/${PHPVERSION}/fpm/conf.d/php-custom.ini"
+  echo " * Copied ${DIR}/php7.2-custom.ini                 to /etc/php/${PHPVERSION}/fpm/conf.d/php-custom.ini"
 
-  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/7.2/fpm/conf.d/opcache.ini"
-  echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/7.2/fpm/conf.d/opcache.ini"
+  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/${PHPVERSION}/fpm/conf.d/opcache.ini"
+  echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/${PHPVERSION}/fpm/conf.d/opcache.ini"
 
-  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/7.2/mods-available/xdebug.ini"
-  echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/7.2/mods-available/xdebug.ini"
+  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/${PHPVERSION}/mods-available/xdebug.ini"
+  echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/${PHPVERSION}/mods-available/xdebug.ini"
 
   if [[ -e /srv/config/php-config/mailcatcher.ini ]]; then
-    cp -f "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.2/mods-available/mailcatcher.ini"
-    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.2/mods-available/mailcatcher.ini"
+    cp -f "/srv/config/php-config/mailcatcher.ini" "/etc/php/${PHPVERSION}/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/${PHPVERSION}/mods-available/mailcatcher.ini"
 
   fi
   if [[ -e /srv/config/php-config/mailhog.ini ]]; then
-    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/7.2/mods-available/mailhog.ini"
-    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/7.2/mods-available/mailhog.ini"
+    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/${PHPVERSION}/mods-available/mailhog.ini"
+    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/${PHPVERSION}/mods-available/mailhog.ini"
   fi
 
-  echo " * Restarting php7.2-fpm service "
-  service php7.2-fpm restart
+  echo " * Restarting php${PHPVERSION}-fpm service "
+  service "php${PHPVERSION}-fpm" restart
 }
 
 package_install
 configure
+
+echo " * Restoring the default PHP CLI version ( ${DEFAULTPHP} )"
+update-alternatives --set php "/usr/bin/php${DEFAULTPHP}"
+update-alternatives --set phar "/usr/bin/phar${DEFAULTPHP}"
+update-alternatives --set phar.phar "/usr/bin/phar.phar${DEFAULTPHP}"
+update-alternatives --set phpize "/usr/bin/phpize${DEFAULTPHP}"
+update-alternatives --set php-config "/usr/bin/php-config${DEFAULTPHP}"
 
 echo " * PHP 7.2 provisioning complete"

--- a/php73/provision.sh
+++ b/php73/provision.sh
@@ -3,6 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # PACKAGE INSTALLATION
+DEFAULTPHP=$(php -r "echo substr(phpversion(),0,3);")
 PHPVERSION="7.3"
 
 apt_package_install_list=(
@@ -72,43 +73,43 @@ configure() {
   echo " * Copied ${DIR}/php7.3-upstream.conf              to /etc/nginx/upstreams/php73.conf"
 
   # Copy php-fpm configuration from local
-  cp -f "${DIR}/php7.3-fpm.conf" "/etc/php/7.3/fpm/php-fpm.conf"
-  echo " * Copied ${DIR}/php7.3-fpm.conf                   to /etc/php/7.3/fpm/php-fpm.conf"
+  cp -f "${DIR}/php7.3-fpm.conf" "/etc/php/${PHPVERSION}/fpm/php-fpm.conf"
+  echo " * Copied ${DIR}/php7.3-fpm.conf                   to /etc/php/${PHPVERSION}/fpm/php-fpm.conf"
 
-  cp -f "${DIR}/php7.3-www.conf" "/etc/php/7.3/fpm/pool.d/www.conf"
-  echo " * Copied ${DIR}/php7.3-www.conf                   to /etc/php/7.3/fpm/pool.d/www.conf"
+  cp -f "${DIR}/php7.3-www.conf" "/etc/php/${PHPVERSION}/fpm/pool.d/www.conf"
+  echo " * Copied ${DIR}/php7.3-www.conf                   to /etc/php/${PHPVERSION}/fpm/pool.d/www.conf"
 
-  cp -f "${DIR}/php7.3-custom.ini" "/etc/php/7.3/fpm/conf.d/php-custom.ini"
-  echo " * Copied ${DIR}/php7.3-custom.ini                 to /etc/php/7.3/fpm/conf.d/php-custom.ini"
+  cp -f "${DIR}/php7.3-custom.ini" "/etc/php/${PHPVERSION}/fpm/conf.d/php-custom.ini"
+  echo " * Copied ${DIR}/php7.3-custom.ini                 to /etc/php/${PHPVERSION}/fpm/conf.d/php-custom.ini"
 
-  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/7.3/fpm/conf.d/opcache.ini"
-  echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/7.3/fpm/conf.d/opcache.ini"
+  cp -f "/srv/config/php-config/opcache.ini" "/etc/php/${PHPVERSION}/fpm/conf.d/opcache.ini"
+  echo " * Copied /srv/config/php-config/opcache.ini       to /etc/php/${PHPVERSION}/fpm/conf.d/opcache.ini"
 
-  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/7.3/mods-available/xdebug.ini"
-  echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/7.3/mods-available/xdebug.ini"
+  cp -f "/srv/config/php-config/xdebug.ini" "/etc/php/${PHPVERSION}/mods-available/xdebug.ini"
+  echo " * Copied /srv/config/php-config/xdebug.ini        to /etc/php/${PHPVERSION}/mods-available/xdebug.ini"
 
   if [[ -e /srv/config/php-config/mailcatcher.ini ]]; then
-    cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/7.3/mods-available/mailcatcher.ini"
-    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/7.3/mods-available/mailcatcher.ini"
+    cp "/srv/config/php-config/mailcatcher.ini" "/etc/php/${PHPVERSION}/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-config/mailcatcher.ini   to /etc/php/${PHPVERSION}/mods-available/mailcatcher.ini"
 
   fi
   if [[ -e /srv/config/php-config/mailhog.ini ]]; then
-    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/7.3/mods-available/mailhog.ini"
-    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/7.3/mods-available/mailhog.ini"
+    cp -f "/srv/config/php-config/mailhog.ini" "/etc/php/${PHPVERSION}/mods-available/mailhog.ini"
+    echo " * Copied /srv/config/php-config/mailhog.ini   to /etc/php/${PHPVERSION}/mods-available/mailhog.ini"
   fi
 
-  echo " * Restarting php7.3-fpm service "
-  service php7.3-fpm restart
+  echo " * Restarting php${PHPVERSION}-fpm service "
+  service "php${PHPVERSION}-fpm" restart
 }
 
 package_install
 configure
 
-echo " * Restoring the default PHP CLI version"
-update-alternatives --set php /usr/bin/php7.2
-update-alternatives --set phar /usr/bin/phar7.2
-update-alternatives --set phar.phar /usr/bin/phar.phar7.2
-update-alternatives --set phpize /usr/bin/phpize7.2
-update-alternatives --set php-config /usr/bin/php-config7.2
+echo " * Restoring the default PHP CLI version ( ${DEFAULTPHP} )"
+update-alternatives --set php "/usr/bin/php${DEFAULTPHP}"
+update-alternatives --set phar "/usr/bin/phar${DEFAULTPHP}"
+update-alternatives --set phar.phar "/usr/bin/phar.phar${DEFAULTPHP}"
+update-alternatives --set phpize "/usr/bin/phpize${DEFAULTPHP}"
+update-alternatives --set php-config "/usr/bin/php-config${DEFAULTPHP}"
 
 echo " * PHP 7.3 provisioning complete"

--- a/php74/provision.sh
+++ b/php74/provision.sh
@@ -3,7 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # PACKAGE INSTALLATION
-
+DEFAULTPHP=$(php -r "echo substr(phpversion(),0,3);")
 PHPVERSION="7.4"
 
 apt_package_install_list=(
@@ -105,11 +105,11 @@ configure() {
 package_install
 configure
 
-echo " * Restoring the default PHP CLI version"
-update-alternatives --set php /usr/bin/php7.2
-update-alternatives --set phar /usr/bin/phar7.2
-update-alternatives --set phar.phar /usr/bin/phar.phar7.2
-update-alternatives --set phpize /usr/bin/phpize7.2
-update-alternatives --set php-config /usr/bin/php-config7.2
+echo " * Restoring the default PHP CLI version ( ${DEFAULTPHP} )"
+update-alternatives --set php "/usr/bin/php${DEFAULTPHP}"
+update-alternatives --set phar "/usr/bin/phar${DEFAULTPHP}"
+update-alternatives --set phar.phar "/usr/bin/phar.phar${DEFAULTPHP}"
+update-alternatives --set phpize "/usr/bin/phpize${DEFAULTPHP}"
+update-alternatives --set php-config "/usr/bin/php-config${DEFAULTPHP}"
 
 echo " * PHP ${PHPVERSION} provisioning complete"

--- a/php80/provision.sh
+++ b/php80/provision.sh
@@ -3,7 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # PACKAGE INSTALLATION
-
+DEFAULTPHP=$(php -r "echo substr(phpversion(),0,3);")
 PHPVERSION="8.0"
 
 apt_package_install_list=(
@@ -104,11 +104,11 @@ configure() {
 package_install
 configure
 
-echo " * Restoring the default PHP CLI version"
-update-alternatives --set php /usr/bin/php7.2
-update-alternatives --set phar /usr/bin/phar7.2
-update-alternatives --set phar.phar /usr/bin/phar.phar7.2
-update-alternatives --set phpize /usr/bin/phpize7.2
-update-alternatives --set php-config /usr/bin/php-config7.2
+echo " * Restoring the default PHP CLI version ( ${DEFAULTPHP} )"
+update-alternatives --set php "/usr/bin/php${DEFAULTPHP}"
+update-alternatives --set phar "/usr/bin/phar${DEFAULTPHP}"
+update-alternatives --set phar.phar "/usr/bin/phar.phar${DEFAULTPHP}"
+update-alternatives --set phpize "/usr/bin/phpize${DEFAULTPHP}"
+update-alternatives --set php-config "/usr/bin/php-config${DEFAULTPHP}"
 
 echo " * PHP ${PHPVERSION} provisioning complete"


### PR DESCRIPTION
Utilities currently assume 7.2 is the version that comes with PHP, but this will be incorrect once 7.3 is used.

So this PR attempts to discover the current default prior to provisioning, then change it back aftwards