### PR TITLE
Tideways CLI

### DIFF
--- a/tideways/tideways-header.php
+++ b/tideways/tideways-header.php
@@ -4,7 +4,7 @@ $is_vvv_tideways = false;
 
 if ( empty( $_SERVER['REMOTE_ADDR'] ) and !isset( $_SERVER['HTTP_USER_AGENT'] ) and count( $_SERVER['argv']) > 0 ) {
     // CLI
-    if ( isset( $_ENV['ENABLE_TIDEWAYS_CLI'] ) && $_ENV['ENABLE_TIDEWAYS_CLI'] === '1' ) {
+    if ( isset( $_SERVER['ENABLE_TIDEWAYS_CLI'] ) && $_SERVER['ENABLE_TIDEWAYS_CLI'] === '1' ) {
         $is_vvv_tideways = true;
     }
 } else {

--- a/tideways/tideways-header.php
+++ b/tideways/tideways-header.php
@@ -1,25 +1,29 @@
 <?php
 
-// don't run on CLI
-if ( empty($_SERVER['REMOTE_ADDR']) and !isset($_SERVER['HTTP_USER_AGENT']) and count($_SERVER['argv']) > 0) {
-    return;
-}
-
-if ( !isset( $_SERVER['HTTP_HOST'] ) ) {
-    return;
-}
-if ( strpos( $_SERVER['HTTP_HOST'], 'vvv.test' ) != false ) {
-    return;
-}
-
 $is_vvv_tideways = false;
 
-if ( file_exists( '/srv/config/tideways.json' ) && in_array( $_SERVER['HTTP_HOST'], json_decode( file_get_contents( '/srv/config/tideways.json' ) ) ) ) {
-    $is_vvv_tideways = true;
-}
+if ( empty( $_SERVER['REMOTE_ADDR'] ) and !isset( $_SERVER['HTTP_USER_AGENT'] ) and count( $_SERVER['argv']) > 0 ) {
+    // CLI
+    if ( isset( $_ENV['ENABLE_TIDEWAYS_CLI'] ) && $_ENV['ENABLE_TIDEWAYS_CLI'] === '1' ) {
+        $is_vvv_tideways = true;
+    }
+} else {
+    // Web requests:
+    if ( !isset( $_SERVER['HTTP_HOST'] ) ) {
+        return;
+    }
 
-if ( isset( $_REQUEST['enable-tideways'] ) && ( $_REQUEST['enable-tideways'] == true ) ) {
-    $is_vvv_tideways = true;
+    if ( strpos( $_SERVER['HTTP_HOST'], 'vvv.test' ) != false ) {
+        return;
+    }
+
+    if ( file_exists( '/srv/config/tideways.json' ) && in_array( $_SERVER['HTTP_HOST'], json_decode( file_get_contents( '/srv/config/tideways.json' ) ) ) ) {
+        $is_vvv_tideways = true;
+    }
+
+    if ( isset( $_REQUEST['enable-tideways'] ) && ( $_REQUEST['enable-tideways'] == true ) ) {
+        $is_vvv_tideways = true;
+    }
 }
 
 if( ! $is_vvv_tideways ) {
@@ -30,5 +34,5 @@ if ( file_exists( '/srv/www/default/php-profiler/config.php' ) ) {
     include '/srv/www/default/php-profiler/config.php';
 }
 
-// Query monitor it will be disabled with TIdeways/XHGUI PHP Profiler
+// Disable Query monitor when using TIdeways/XHGUI PHP Profiler
 define( 'QM_DISABLED', true );


### PR DESCRIPTION
Allow tideways to run if ENABLE_TIDEWAYS_CLI is defined as an environment variable

In theory something like this would work:

```sh
export ENABLE_TIDEWAYS_CLI=1
wp ...
```