### PR TITLE
revert(php): add by php version xdebug, ssh2 and pcov

### DIFF
--- a/php56/provision.sh
+++ b/php56/provision.sh
@@ -37,6 +37,9 @@ apt_package_install_list=(
   "php${PHPVERSION}-soap"
   "php${PHPVERSION}-xml"
   "php${PHPVERSION}-zip"
+  "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
 )
 
 ### FUNCTIONS

--- a/php70/provision.sh
+++ b/php70/provision.sh
@@ -37,6 +37,9 @@ apt_package_install_list=(
   "php${PHPVERSION}-soap"
   "php${PHPVERSION}-xml"
   "php${PHPVERSION}-zip"
+  "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
 )
 
 ### FUNCTIONS

--- a/php71/provision.sh
+++ b/php71/provision.sh
@@ -38,6 +38,9 @@ apt_package_install_list=(
   "php${PHPVERSION}-soap"
   "php${PHPVERSION}-xml"
   "php${PHPVERSION}-zip"
+  "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
 )
 
 ### FUNCTIONS

--- a/php72/provision.sh
+++ b/php72/provision.sh
@@ -38,6 +38,9 @@ apt_package_install_list=(
   "php${PHPVERSION}-soap"
   "php${PHPVERSION}-xml"
   "php${PHPVERSION}-zip"
+  "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
 )
 
 ### FUNCTIONS

--- a/php73/provision.sh
+++ b/php73/provision.sh
@@ -38,6 +38,9 @@ apt_package_install_list=(
   "php${PHPVERSION}-soap"
   "php${PHPVERSION}-xml"
   "php${PHPVERSION}-zip"
+  "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
 )
 
 ### FUNCTIONS

--- a/php74/provision.sh
+++ b/php74/provision.sh
@@ -38,6 +38,9 @@ apt_package_install_list=(
   "php${PHPVERSION}-soap"
   "php${PHPVERSION}-xml"
   "php${PHPVERSION}-zip"
+  "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
 )
 
 ### FUNCTIONS

--- a/php80/provision.sh
+++ b/php80/provision.sh
@@ -37,6 +37,9 @@ apt_package_install_list=(
   "php${PHPVERSION}-soap"
   "php${PHPVERSION}-xml"
   "php${PHPVERSION}-zip"
+  "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
 )
 
 ### FUNCTIONS


### PR DESCRIPTION
https://github.com/Varying-Vagrant-Vagrants/vvv-utilities/commit/4f4fc8b0866ef8c43ba4d778d2750a6c26630e5b removed those packages but they weren't for versions, this pr fix it so they are not available again.