### PR TITLE
Fix for missing methods

### DIFF
--- a/tideways/config.php-profiler.php
+++ b/tideways/config.php-profiler.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once 'vendor/perftools/php-profiler/autoload.php';
 require_once 'vendor/autoload.php';
 
 $config = array(


### PR DESCRIPTION
The php-profiler explains that also this autoload is required