### PR TITLE
Don't load php-profiler on CLI

### DIFF
--- a/tideways/config.php-profiler.php
+++ b/tideways/config.php-profiler.php
@@ -1,7 +1,11 @@
 <?php
+// We don't install tideways for CLI so we can avoid to load this file at all
+if ( php_sapi_name() === "cli" ) {
+    return;
+}
 
-if ( file_exists( 'vendor/perftools/php-profiler/autoload.php' ) ) {
-    require_once 'vendor/perftools/php-profiler/autoload.php';
+if ( file_exists( './vendor/perftools/php-profiler/autoload.php' ) ) {
+    require_once './vendor/perftools/php-profiler/autoload.php';
 } else {
     error_log(
         'Failed to load the PHP Profiler autoloader.php file, confirm provisioning of tideways was succesful, ' .


### PR DESCRIPTION
As we don't install tideways for CLI

Otherwise we get:
```
    default:  ▷ Running the 'site-community' provisioner...
    default:  * Pulling down the master branch of https://github.com/Varying-Vagrant-Vagrants/custom-site-template
    default: From https://github.com/Varying-Vagrant-Vagrants/custom-site-template
    default:  * branch            master     -> FETCH_HEAD
    default: Failed to load the PHP Profiler autoloader.php file, confirm provisioning of tideways was succesful, reprovision, and if all else fails delete the php-profiler folder in /srv/www/default and report on the VVV github
    default: Failed to load the PHP Profiler autoloader.php file, confirm provisioning of tideways was succesful, reprovision, and if all else fails delete the php-profiler folder in /srv/www/default and report on the VVV github
    default: Failed to load the PHP Profiler autoloader.php file, confirm provisioning of tideways was succesful, reprovision, and if all else fails delete the php-profiler folder in /srv/www/default and report on the VVV github
    default: Failed to load the PHP Profiler autoloader.php file, confirm provisioning of tideways was succesful, reprovision, and if all else fails delete the php-profiler folder in /srv/www/default and report on the VVV github
    default: Failed to load the PHP Profiler autoloader.php file, confirm provisioning of tideways was succesful, reprovision, and if all else fails delete the php-profiler folder in /srv/www/default and report on the VVV github
    default: Failed to load the PHP Profiler autoloader.php file, confirm provisioning of tideways was succesful, reprovision, and if all else fails delete the php-profiler folder in /srv/www/default and report on the VVV github
```