### PR TITLE
Don't load php-profiler on CLI (right branch)

### DIFF
--- a/tideways/config.php-profiler.php
+++ b/tideways/config.php-profiler.php
@@ -1,7 +1,11 @@
 <?php
+// We don't install tideways for CLI so we can avoid to load this file at all
+if ( php_sapi_name() === "cli" ) {
+    return;
+}
 
-if ( file_exists( 'vendor/perftools/php-profiler/autoload.php' ) ) {
-    require_once 'vendor/perftools/php-profiler/autoload.php';
+if ( file_exists( './vendor/perftools/php-profiler/autoload.php' ) ) {
+    require_once './vendor/perftools/php-profiler/autoload.php';
 } else {
     error_log(
         'Failed to load the PHP Profiler autoloader.php file, confirm provisioning of tideways was succesful, ' .


### PR DESCRIPTION
So yesterday I did the PR but in the wrong branch...
https://github.com/Varying-Vagrant-Vagrants/vvv-utilities/pull/100