### PR TITLE
Enable commented out packages in newer PHP versions

### DIFF
--- a/php82/provision.sh
+++ b/php82/provision.sh
@@ -21,12 +21,12 @@ apt_package_install_list=(
   "php${PHPVERSION}-dev"
 
   # Extra PHP modules that we find useful (commented out modules are not yet available)
-  # "php${PHPVERSION}-imagick"
-  # "php${PHPVERSION}-memcache"
-  # "php${PHPVERSION}-memcached"
-  # "php${PHPVERSION}-pcov"
-  # "php${PHPVERSION}-ssh2"
-  # "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-imagick"
+  "php${PHPVERSION}-memcache"
+  "php${PHPVERSION}-memcached"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
+  "php${PHPVERSION}-xdebug"
   "php${PHPVERSION}-bcmath"
   "php${PHPVERSION}-curl"
   "php${PHPVERSION}-gd"

--- a/php83/provision.sh
+++ b/php83/provision.sh
@@ -21,12 +21,12 @@ apt_package_install_list=(
   "php${PHPVERSION}-dev"
 
   # Extra PHP modules that we find useful (commented out modules are not yet available)
-  # "php${PHPVERSION}-imagick"
-  # "php${PHPVERSION}-memcache"
-  # "php${PHPVERSION}-memcached"
-  # "php${PHPVERSION}-pcov"
-  # "php${PHPVERSION}-ssh2"
-  # "php${PHPVERSION}-xdebug"
+  "php${PHPVERSION}-imagick"
+  "php${PHPVERSION}-memcache"
+  "php${PHPVERSION}-memcached"
+  "php${PHPVERSION}-pcov"
+  "php${PHPVERSION}-ssh2"
+  "php${PHPVERSION}-xdebug"
   "php${PHPVERSION}-bcmath"
   "php${PHPVERSION}-curl"
   "php${PHPVERSION}-gd"


### PR DESCRIPTION
These packages weren't ready at first but they should be now