### PR TITLE
Add Ubuntu 26.04 (resolute) support to MongoDB provisioner

### DIFF
--- a/mongodb/provision.sh
+++ b/mongodb/provision.sh
@@ -26,8 +26,9 @@ get_mongodb_config() {
             # Ubuntu 16.04-22.04 - MongoDB 4.4
             echo "4.4 ${codename} mongo"
             ;;
-        noble)
-            # Ubuntu 24.04 - MongoDB 8.0 (first version with official Noble support)
+        noble|resolute)
+            # Ubuntu 24.04 (noble) and 26.04 (resolute) - MongoDB 8.0.
+            # resolute uses the noble repo until MongoDB publishes a resolute one.
             echo "8.0 noble mongosh"
             ;;
         *)


### PR DESCRIPTION
## What

Adds the Ubuntu 26.04 LTS codename `resolute` to the MongoDB provisioner's `get_mongodb_config()` codename map.

`resolute` shares the `noble` case arm (`noble|resolute)`), resolving to MongoDB 8.0 from the `noble` apt repo. MongoDB has not published a `resolute` apt suite yet, so the `noble` repo is used as the fallback (noble-built packages run fine on 26.04). This mirrors the existing `xenial|bionic|focal|jammy` grouping style.

## Why

Part of adding Ubuntu 26.04 support to VVV. Without this, provisioning MongoDB on a fresh 26.04 box falls through to the `*)` default and prints a `Warning: Unknown Ubuntu codename 'resolute'` line every run. Grouping `resolute` with `noble` documents the intended behaviour and silences the warning. When MongoDB ships a `resolute` apt suite, `resolute` can be split into its own arm.

## Testing

- `bash -n mongodb/provision.sh` passes.
- `get_mongodb_config resolute` returns `8.0 noble mongosh` with no warning (verified in isolation).
- `noble` / `jammy` cases unchanged.

## Related

Companion to the Ubuntu 26.04 support work in the main VVV repo (separate PR).